### PR TITLE
Add feature to let user create vanilla server by official api

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.0.1",
+  "flutterSdkVersion": "3.3.10",
   "flavors": {}
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ import 'package:server_properties_repository/server_properties_repository.dart';
 import 'package:server_repository/server_repository.dart';
 import 'package:system_repository/system_repository.dart';
 import 'package:url_launcher/url_launcher_string.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 void main(List<String> args) async {
   const isProduction = bool.fromEnvironment('dart.vm.product');
@@ -100,6 +101,8 @@ void main(List<String> args) async {
     fileSystem: fileSystem,
   );
 
+  final vanillaServerRepository = VanillaServerRepository(dio: dio);
+
   final AppUpdaterRepository appUpdaterRepository =
       AppUpdaterRepository(dio: dio);
 
@@ -136,6 +139,7 @@ void main(List<String> args) async {
       installerCreatorRepository: installerCreatorRepository,
       appUpdaterRepository: appUpdaterRepository,
       serverConfigurationRepository: serverConfigurationRepository,
+      vanillaServerRepository: vanillaServerRepository,
     ),
   );
   await DesktopWindow.setWindowSize(const Size(1400, 900));

--- a/lib/pages/app_page/app.dart
+++ b/lib/pages/app_page/app.dart
@@ -27,6 +27,7 @@ import 'package:server_management_repository/server_management_repository.dart';
 import 'package:server_properties_repository/server_properties_repository.dart';
 import 'package:server_repository/server_repository.dart';
 import 'package:system_repository/system_repository.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 class CubeApp extends StatelessWidget {
   const CubeApp({
@@ -51,6 +52,7 @@ class CubeApp extends StatelessWidget {
     required this.installerCreatorRepository,
     required this.appUpdaterRepository,
     required this.serverConfigurationRepository,
+    required this.vanillaServerRepository,
     Key? key,
   }) : super(key: key);
   final LocaleRepository localeRepository;
@@ -74,6 +76,7 @@ class CubeApp extends StatelessWidget {
   final InstallerCreatorRepository installerCreatorRepository;
   final AppUpdaterRepository appUpdaterRepository;
   final ServerConfigurationRepository serverConfigurationRepository;
+  final VanillaServerRepository vanillaServerRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -129,6 +132,7 @@ class CubeApp extends StatelessWidget {
         RepositoryProvider.value(value: serverPropertiesRepository),
         RepositoryProvider.value(value: installerCreatorRepository),
         RepositoryProvider.value(value: appUpdaterRepository),
+        RepositoryProvider.value(value: vanillaServerRepository),
       ],
       child: BlocProvider<LocaleBloc>(
         create: (_) => LocaleBloc(localeRepository),

--- a/lib/pages/app_page/pages/server_page/bloc/installer_manager_cubit.dart
+++ b/lib/pages/app_page/pages/server_page/bloc/installer_manager_cubit.dart
@@ -1,6 +1,7 @@
 import 'package:bloc/bloc.dart';
 import 'package:cube_api/cube_api.dart';
 import 'package:equatable/equatable.dart';
+import 'package:installer_creator_repository/installer_creator_repository.dart';
 import 'package:server_management_repository/server_management_repository.dart';
 import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
@@ -36,6 +37,7 @@ class InstallerManagerCubit extends Cubit<InstallerManagerState> {
   InstallerManagerCubit({
     required this.serverManagementRepository,
     required this.vanillaServerRepository,
+    required this.installerCreatorRepository,
   }) : super(
           const InstallerManagerState(
             status: NetworkStatus.uninit,
@@ -45,6 +47,7 @@ class InstallerManagerCubit extends Cubit<InstallerManagerState> {
         );
   final ServerManagementRepository serverManagementRepository;
   final VanillaServerRepository vanillaServerRepository;
+  final InstallerCreatorRepository installerCreatorRepository;
 
   Future<void> getInstallers() async {
     emit(state.copyWith(status: NetworkStatus.inProgress));
@@ -66,7 +69,35 @@ class InstallerManagerCubit extends Cubit<InstallerManagerState> {
     }
   }
 
-  // Future<InstallerFile> selectVanillaVersion(
-  //   VanillaManifestVersionInfo info,
-  // ) async {}
+  Future<InstallerFile?> getVanillaInstaller({
+    required VanillaManifestVersionInfo vanillaManifest,
+  }) async {
+    emit(state.copyWith(status: NetworkStatus.inProgress));
+    try {
+      final downloadInfo = await vanillaServerRepository.getServerByVersionInfo(
+        url: vanillaManifest.url,
+      );
+      await serverManagementRepository.createInstallersDir(
+        subfolder: '_vanilla',
+      );
+      final pathToInstaller = await installerCreatorRepository.create(
+        name: vanillaManifest.id,
+        description: vanillaManifest.type,
+        server: downloadInfo.url,
+        type: JarType.vanilla,
+        map: '',
+        settings: [],
+        pack: null,
+        subfolder: '_vanilla',
+      );
+      emit(state.copyWith(status: NetworkStatus.success));
+      return InstallerFile(
+        installer: pathToInstaller.value,
+        path: pathToInstaller.key,
+      );
+    } catch (err) {
+      emit(state.copyWith(status: NetworkStatus.failure));
+      return null;
+    }
+  }
 }

--- a/lib/pages/app_page/pages/server_page/widgets/server_creation_dialog.dart
+++ b/lib/pages/app_page/pages/server_page/widgets/server_creation_dialog.dart
@@ -201,7 +201,11 @@ class VanillaTabView extends StatelessWidget {
     final fakeInstallers = List<InstallerFile>.generate(5, (index) {
       return InstallerFile(
         installer: Installer(
-            'name$index', 'description', JarType.vanilla, 'serverPath'),
+          'name$index',
+          'description',
+          JarType.vanilla,
+          'serverPath',
+        ),
         path: 'path$index',
       );
     });

--- a/lib/pages/app_page/pages/server_page/widgets/server_creation_dialog.dart
+++ b/lib/pages/app_page/pages/server_page/widgets/server_creation_dialog.dart
@@ -41,12 +41,32 @@ class ServerCreationDialogView extends StatefulWidget {
       _ServerCreationDialogViewState();
 }
 
-class _ServerCreationDialogViewState extends State<ServerCreationDialogView> {
+enum ServerCreationType {
+  official,
+  custom,
+}
+
+extension ServerCreationTypeExtension on ServerCreationType {
+  get name {
+    switch (this) {
+      case ServerCreationType.official:
+        return '官方';
+      case ServerCreationType.custom:
+        return '安裝包';
+    }
+  }
+}
+
+class _ServerCreationDialogViewState extends State<ServerCreationDialogView>
+    with TickerProviderStateMixin {
+  late TabController _createTypeTabController;
   late TextEditingController _controller;
   InstallerFile? _selectedInstaller;
   @override
   void initState() {
     context.read<InstallerManagerCubit>().getInstallers();
+    _createTypeTabController =
+        TabController(length: ServerCreationType.values.length, vsync: this);
     _controller = TextEditingController();
     _controller.addListener(() {
       setState(() {});
@@ -56,12 +76,14 @@ class _ServerCreationDialogViewState extends State<ServerCreationDialogView> {
 
   @override
   void dispose() {
+    _createTypeTabController.dispose();
     _controller.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final colorTheme = Theme.of(context).colorScheme;
     final isCreatable =
         _controller.text.isNotEmpty && _selectedInstaller != null;
     return AlertDialog(
@@ -74,6 +96,21 @@ class _ServerCreationDialogViewState extends State<ServerCreationDialogView> {
           Container(
             height: 3,
             color: Colors.black,
+          ),
+          TabBar(
+            controller: _createTypeTabController,
+            indicator: BoxDecoration(
+              color: colorTheme.primary.withAlpha(200),
+            ),
+            labelColor: colorTheme.onSecondary,
+            unselectedLabelColor: colorTheme.primary.withAlpha(200),
+            tabs: ServerCreationType.values
+                .map(
+                  (type) => Tab(
+                    text: type.name,
+                  ),
+                )
+                .toList(),
           ),
           // Expanded(
           //   child: Container(),

--- a/lib/pages/app_page/pages/server_page/widgets/server_creation_dialog.dart
+++ b/lib/pages/app_page/pages/server_page/widgets/server_creation_dialog.dart
@@ -50,9 +50,9 @@ extension ServerCreationTypeExtension on ServerCreationType {
   get name {
     switch (this) {
       case ServerCreationType.official:
-        return '官方';
+        return serverPageCreationDialogTypeOfficial.i18n;
       case ServerCreationType.custom:
-        return '安裝包';
+        return serverPageCreationDialogTypeCustom.i18n;
     }
   }
 }

--- a/lib/pages/app_page/pages/server_page/widgets/server_creation_dialog.i18n.dart
+++ b/lib/pages/app_page/pages/server_page/widgets/server_creation_dialog.i18n.dart
@@ -6,6 +6,9 @@ const serverPageCreationDialogSelectInstaller =
 const serverPageCreationDialogServerName = 'serverPageCreationDialogServerName';
 const serverPageCreationDialogBack = 'serverPageCreationDialogBack';
 const serverPageCreationDialogCreate = 'serverPageCreationDialogCreate';
+const serverPageCreationDialogTypeOfficial =
+    'serverPageCreationDialogTypeOfficial';
+const serverPageCreationDialogTypeCustom = 'serverPageCreationDialogTypeCustom';
 
 extension Localization on String {
   static final _t = Translations.from(
@@ -27,6 +30,14 @@ extension Localization on String {
         AppLocalization.enUS.name: 'Create',
         AppLocalization.zhTW.name: '建立',
       },
+      serverPageCreationDialogTypeOfficial: {
+        AppLocalization.enUS.name: 'Vanilla',
+        AppLocalization.zhTW.name: '原味',
+      },
+      serverPageCreationDialogTypeCustom: {
+        AppLocalization.enUS.name: 'Installer',
+        AppLocalization.zhTW.name: '安裝包',
+      }
     },
   );
 

--- a/packages/installer_creator_repository/lib/src/installer_creator_repository.dart
+++ b/packages/installer_creator_repository/lib/src/installer_creator_repository.dart
@@ -19,7 +19,7 @@ class InstallerCreatorRepository {
     FileSystem? fileSystem,
   }) : _fileSystem = fileSystem ?? const LocalFileSystem();
 
-  Future<void> create({
+  Future<MapEntry<String, Installer>> create({
     required String name,
     required String description,
     required String server,
@@ -46,5 +46,7 @@ class InstallerCreatorRepository {
     );
     final raw = jsonEncode(installer.toJson());
     await file.writeAsString(raw);
+
+    return MapEntry(file.absolute.path, installer);
   }
 }

--- a/packages/installer_creator_repository/lib/src/installer_creator_repository.dart
+++ b/packages/installer_creator_repository/lib/src/installer_creator_repository.dart
@@ -27,8 +27,13 @@ class InstallerCreatorRepository {
     required String map,
     required List<ModelSetting> settings,
     required ModelPack? pack,
+    String? subfolder,
   }) async {
-    final file = _fileSystem.file(p.join('installers', '$name.dmc'));
+    String path = p.join('installers', '$name.dmc');
+    if (subfolder != null && subfolder.isNotEmpty) {
+      path = p.join('installers', subfolder, '$name.dmc');
+    }
+    final file = _fileSystem.file(path);
     await file.create(recursive: true);
     final installer = Installer(
       name,

--- a/packages/installer_creator_repository/test/installer_creator_repository_ig_test.dart
+++ b/packages/installer_creator_repository/test/installer_creator_repository_ig_test.dart
@@ -97,6 +97,43 @@ void main() {
           ]),
         );
       });
+
+      test('return normally with subfolder', () async {
+        const subfolder = '123';
+        await expectLater(
+          repository.create(
+            name: name,
+            description: description,
+            server: server,
+            type: type,
+            map: map,
+            settings: settings,
+            pack: pack,
+            subfolder: subfolder,
+          ),
+          completes,
+        );
+
+        final file =
+            fileSystem.file(p.join('installers', subfolder, '$name.dmc'));
+        expect(await file.exists(), isTrue);
+        final data = await file.readAsString();
+        expect(
+          data,
+          allOf([
+            contains(name),
+            contains(description),
+            contains(server),
+            contains(describeEnum(type)),
+            contains(map),
+            ...settings.map((s) => contains(s.name)),
+            ...settings.map((s) => contains(s.path)),
+            ...settings.map((s) => contains(s.program)),
+            contains(pack.path),
+            contains(pack.description),
+          ]),
+        );
+      });
     });
   });
 }

--- a/packages/installer_creator_repository/test/installer_creator_repository_ig_test.dart
+++ b/packages/installer_creator_repository/test/installer_creator_repository_ig_test.dart
@@ -65,20 +65,30 @@ void main() {
       ];
       const pack = ModelPack(path: 'https://pack', description: 'packDesc');
       test('return normally', () async {
-        await expectLater(
-          repository.create(
-            name: name,
-            description: description,
-            server: server,
-            type: type,
-            map: map,
-            settings: settings,
-            pack: pack,
+        final result = await repository.create(
+          name: name,
+          description: description,
+          server: server,
+          type: type,
+          map: map,
+          settings: settings,
+          pack: pack,
+        );
+        expect(
+          result.value,
+          const Installer(
+            name,
+            description,
+            type,
+            server,
+            mapZipPath: map,
+            modelSettings: settings,
+            modelPack: pack,
           ),
-          completes,
         );
 
         final file = fileSystem.file(p.join('installers', '$name.dmc'));
+        expect(result.key, file.absolute.path);
         expect(await file.exists(), isTrue);
         final data = await file.readAsString();
         expect(
@@ -100,22 +110,32 @@ void main() {
 
       test('return normally with subfolder', () async {
         const subfolder = '123';
-        await expectLater(
-          repository.create(
-            name: name,
-            description: description,
-            server: server,
-            type: type,
-            map: map,
-            settings: settings,
-            pack: pack,
-            subfolder: subfolder,
+        final result = await repository.create(
+          name: name,
+          description: description,
+          server: server,
+          type: type,
+          map: map,
+          settings: settings,
+          pack: pack,
+          subfolder: subfolder,
+        );
+        expect(
+          result.value,
+          const Installer(
+            name,
+            description,
+            type,
+            server,
+            mapZipPath: map,
+            modelSettings: settings,
+            modelPack: pack,
           ),
-          completes,
         );
 
         final file =
             fileSystem.file(p.join('installers', subfolder, '$name.dmc'));
+        expect(result.key, file.absolute.path);
         expect(await file.exists(), isTrue);
         final data = await file.readAsString();
         expect(

--- a/packages/installer_creator_repository/test/installer_creator_repository_test.dart
+++ b/packages/installer_creator_repository/test/installer_creator_repository_test.dart
@@ -135,6 +135,36 @@ void main() {
           completes,
         );
       });
+
+      test('return normally in subfolder', () async {
+        const subfolder = '123';
+        final file = MockFile();
+        when(
+          () => fileSystem.file(
+            p.join('installers', subfolder, '$name.dmc'),
+          ),
+        ).thenReturn(file);
+        when(() => file.create(recursive: true)).thenAnswer((_) async => file);
+        when(() => file.writeAsString(captureAny()))
+            .thenAnswer((_) async => file);
+        await expectLater(
+          repository.create(
+            name: name,
+            description: description,
+            server: server,
+            type: type,
+            map: map,
+            settings: settings,
+            pack: pack,
+            subfolder: subfolder,
+          ),
+          completes,
+        );
+
+        verify(
+          () => fileSystem.file(p.join('installers', subfolder, '$name.dmc')),
+        ).called(1);
+      });
     });
   });
 }

--- a/packages/installer_creator_repository/test/installer_creator_repository_test.dart
+++ b/packages/installer_creator_repository/test/installer_creator_repository_test.dart
@@ -116,53 +116,78 @@ void main() {
       });
 
       test('return normally', () async {
+        final path = p.join('installers', '$name.dmc');
         final file = MockFile();
-        when(() => fileSystem.file(p.join('installers', '$name.dmc')))
-            .thenReturn(file);
+        when(() => fileSystem.file(path)).thenReturn(file);
         when(() => file.create(recursive: true)).thenAnswer((_) async => file);
         when(() => file.writeAsString(captureAny()))
             .thenAnswer((_) async => file);
-        await expectLater(
-          repository.create(
-            name: name,
-            description: description,
-            server: server,
-            type: type,
-            map: map,
-            settings: settings,
-            pack: pack,
+        when(() => file.absolute).thenReturn(file);
+        when(() => file.path).thenReturn(path);
+        final result = await repository.create(
+          name: name,
+          description: description,
+          server: server,
+          type: type,
+          map: map,
+          settings: settings,
+          pack: pack,
+        );
+        expect(result.key, path);
+        expect(
+          result.value,
+          const Installer(
+            name,
+            description,
+            type,
+            server,
+            mapZipPath: map,
+            modelSettings: settings,
+            modelPack: pack,
           ),
-          completes,
         );
       });
 
       test('return normally in subfolder', () async {
         const subfolder = '123';
+        final path = p.join('installers', subfolder, '$name.dmc');
         final file = MockFile();
         when(
           () => fileSystem.file(
-            p.join('installers', subfolder, '$name.dmc'),
+            path,
           ),
         ).thenReturn(file);
         when(() => file.create(recursive: true)).thenAnswer((_) async => file);
         when(() => file.writeAsString(captureAny()))
             .thenAnswer((_) async => file);
-        await expectLater(
-          repository.create(
-            name: name,
-            description: description,
-            server: server,
-            type: type,
-            map: map,
-            settings: settings,
-            pack: pack,
-            subfolder: subfolder,
+        when(() => file.absolute).thenReturn(file);
+        when(() => file.path).thenReturn(path);
+        final result = await repository.create(
+          name: name,
+          description: description,
+          server: server,
+          type: type,
+          map: map,
+          settings: settings,
+          pack: pack,
+          subfolder: subfolder,
+        );
+        expect(result.key, path);
+        expect(
+          result.value,
+          const Installer(
+            name,
+            description,
+            type,
+            server,
+            mapZipPath: map,
+            modelSettings: settings,
+            modelPack: pack,
           ),
-          completes,
         );
 
         verify(
-          () => fileSystem.file(p.join('installers', subfolder, '$name.dmc')),
+          () => fileSystem.file(path),
         ).called(1);
       });
     });

--- a/packages/server_management_repository/lib/src/server_management_repository.dart
+++ b/packages/server_management_repository/lib/src/server_management_repository.dart
@@ -54,9 +54,15 @@ class ServerManagementRepository {
     }
   }
 
-  Future<String> createInstallersDir() async {
-    final installerDir = _installersDir;
+  Future<String> createInstallersDir({String? subfolder}) async {
+    Directory installerDir = _installersDir;
+
+    if (subfolder != null && subfolder.isNotEmpty) {
+      installerDir = installerDir.childDirectory(subfolder);
+    }
+
     await installerDir.create(recursive: true);
+
     return installerDir.absolute.path;
   }
 

--- a/packages/server_management_repository/test/server_management_repository_ig_test.dart
+++ b/packages/server_management_repository/test/server_management_repository_ig_test.dart
@@ -80,6 +80,27 @@ void main() {
           isTrue,
         );
       });
+
+      test('create installers directory with subfolder at rootPath', () async {
+        const subfolder = '123';
+        expect(
+          await fileSystem
+              .directory(p.join(rootPath.path, 'installers', subfolder))
+              .exists(),
+          isFalse,
+        );
+        expect(
+          await repository.createInstallersDir(subfolder: subfolder),
+          p.join(rootPath.path, 'installers', subfolder),
+        );
+
+        expect(
+          await fileSystem
+              .directory(p.join(rootPath.path, 'installers', subfolder))
+              .exists(),
+          isTrue,
+        );
+      });
     });
 
     group('getInstallers', () {

--- a/packages/server_management_repository/test/server_management_repository_test.dart
+++ b/packages/server_management_repository/test/server_management_repository_test.dart
@@ -79,6 +79,33 @@ void main() {
         expect(captured.last, 'installers');
         verify(() => directory.create(recursive: true)).called(1);
       });
+
+      test('call create with subfolder', () async {
+        const subfolder = '123';
+        Directory directory = MockDirectory();
+        when(() => fileSystem.directory(captureAny())).thenReturn(directory);
+        when(() => directory.create(recursive: true)).thenAnswer(
+          (_) async => directory,
+        );
+        when(() => directory.absolute).thenReturn(
+          directory,
+        );
+        when(() => directory.childDirectory(subfolder)).thenReturn(
+          directory,
+        );
+        when(() => directory.path).thenReturn(
+          '/absolute/installers/$subfolder',
+        );
+        expect(
+          await repository.createInstallersDir(subfolder: subfolder),
+          '/absolute/installers/$subfolder',
+        );
+        final captured =
+            verify(() => fileSystem.directory(captureAny())).captured;
+        expect(captured.last, 'installers');
+        verify(() => directory.childDirectory(subfolder)).called(1);
+        verify(() => directory.create(recursive: true)).called(1);
+      });
     });
 
     group('getInstallers', () {

--- a/packages/vanilla_server_repository/analysis_options.yaml
+++ b/packages/vanilla_server_repository/analysis_options.yaml
@@ -1,0 +1,13 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    library_prefixes: false
+    omit_local_variable_types: false
+    require_trailing_commas: true
+    # prefer_relative_imports: false
+    # lines_longer_than_80_chars: false
+    # public_member_api_docs: false
+    # avoid_types_on_closure_parameters: false
+analyzer:
+  exclude: [lib/**.g.dart, test/**.mocks.dart]

--- a/packages/vanilla_server_repository/dart_test.yaml
+++ b/packages/vanilla_server_repository/dart_test.yaml
@@ -1,0 +1,12 @@
+file_reporters:
+  json: reports/test-results.json
+tags:
+  utility:
+  repository:
+  page:
+  component:
+  slow:
+  unittest:
+  integration:
+  widget:
+  debug:

--- a/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest.dart
@@ -1,0 +1,2 @@
+export './vanilla_manifest_info.dart';
+export './vanilla_manifest_version_info.dart';

--- a/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_info.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_info.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:system_repository/src/vanilla_manifest/vanilla_manifest_version_info.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 part 'vanilla_manifest_info.g.dart';
 

--- a/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_info.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_info.dart
@@ -1,0 +1,21 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:system_repository/src/vanilla_manifest/vanilla_manifest_version_info.dart';
+
+part 'vanilla_manifest_info.g.dart';
+
+@JsonSerializable()
+class VanillaManifestInfo extends Equatable {
+  const VanillaManifestInfo({
+    required this.versions,
+  });
+  final List<VanillaManifestVersionInfo> versions;
+
+  factory VanillaManifestInfo.fromJson(Map<String, dynamic> json) =>
+      _$VanillaManifestInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VanillaManifestInfoToJson(this);
+
+  @override
+  List<Object> get props => [versions];
+}

--- a/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_info.g.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_info.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vanilla_manifest_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+VanillaManifestInfo _$VanillaManifestInfoFromJson(Map<String, dynamic> json) =>
+    VanillaManifestInfo(
+      versions: (json['versions'] as List<dynamic>)
+          .map((e) =>
+              VanillaManifestVersionInfo.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$VanillaManifestInfoToJson(
+        VanillaManifestInfo instance) =>
+    <String, dynamic>{
+      'versions': instance.versions,
+    };

--- a/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_version_info.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_version_info.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'vanilla_manifest_version_info.g.dart';
+
+@JsonSerializable()
+class VanillaManifestVersionInfo extends Equatable {
+  const VanillaManifestVersionInfo({
+    required this.id,
+    required this.type,
+    required this.url,
+    required this.time,
+    required this.releaseTime,
+  });
+  final String id;
+  final String type;
+  final String url;
+  final DateTime time;
+  final DateTime releaseTime;
+
+  factory VanillaManifestVersionInfo.fromJson(Map<String, dynamic> json) =>
+      _$VanillaManifestVersionInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VanillaManifestVersionInfoToJson(this);
+
+  @override
+  List<Object> get props {
+    return [
+      id,
+      type,
+      url,
+      time,
+      releaseTime,
+    ];
+  }
+}

--- a/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_version_info.g.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_manifest/vanilla_manifest_version_info.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vanilla_manifest_version_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+VanillaManifestVersionInfo _$VanillaManifestVersionInfoFromJson(
+        Map<String, dynamic> json) =>
+    VanillaManifestVersionInfo(
+      id: json['id'] as String,
+      type: json['type'] as String,
+      url: json['url'] as String,
+      time: DateTime.parse(json['time'] as String),
+      releaseTime: DateTime.parse(json['releaseTime'] as String),
+    );
+
+Map<String, dynamic> _$VanillaManifestVersionInfoToJson(
+        VanillaManifestVersionInfo instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': instance.type,
+      'url': instance.url,
+      'time': instance.time.toIso8601String(),
+      'releaseTime': instance.releaseTime.toIso8601String(),
+    };

--- a/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server.dart
@@ -1,0 +1,3 @@
+export './vanilla_server_info.dart';
+export './vanilla_server_downloads_info.dart';
+export './vanilla_server_downloads_server_info.dart';

--- a/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_info.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_info.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:system_repository/src/vanilla_server/vanilla_server_downloads_server_info.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 part 'vanilla_server_downloads_info.g.dart';
 

--- a/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_info.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_info.dart
@@ -1,0 +1,21 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:system_repository/src/vanilla_server/vanilla_server_downloads_server_info.dart';
+
+part 'vanilla_server_downloads_info.g.dart';
+
+@JsonSerializable()
+class VanillaServerDownloadsInfo extends Equatable {
+  const VanillaServerDownloadsInfo({
+    required this.server,
+  });
+  final VanillaServerDownloadsServerInfo server;
+
+  factory VanillaServerDownloadsInfo.fromJson(Map<String, dynamic> json) =>
+      _$VanillaServerDownloadsInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VanillaServerDownloadsInfoToJson(this);
+
+  @override
+  List<Object> get props => [server];
+}

--- a/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_info.g.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_info.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vanilla_server_downloads_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+VanillaServerDownloadsInfo _$VanillaServerDownloadsInfoFromJson(
+        Map<String, dynamic> json) =>
+    VanillaServerDownloadsInfo(
+      server: VanillaServerDownloadsServerInfo.fromJson(
+          json['server'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$VanillaServerDownloadsInfoToJson(
+        VanillaServerDownloadsInfo instance) =>
+    <String, dynamic>{
+      'server': instance.server,
+    };

--- a/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_server_info.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_server_info.dart
@@ -1,0 +1,28 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'vanilla_server_downloads_server_info.g.dart';
+
+@JsonSerializable()
+class VanillaServerDownloadsServerInfo extends Equatable {
+  const VanillaServerDownloadsServerInfo({
+    required this.sha1,
+    required this.size,
+    required this.url,
+  });
+
+  final String sha1;
+  final int size;
+  final String url;
+
+  factory VanillaServerDownloadsServerInfo.fromJson(
+    Map<String, dynamic> json,
+  ) =>
+      _$VanillaServerDownloadsServerInfoFromJson(json);
+
+  Map<String, dynamic> toJson() =>
+      _$VanillaServerDownloadsServerInfoToJson(this);
+
+  @override
+  List<Object> get props => [sha1, size, url];
+}

--- a/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_server_info.g.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_downloads_server_info.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vanilla_server_downloads_server_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+VanillaServerDownloadsServerInfo _$VanillaServerDownloadsServerInfoFromJson(
+        Map<String, dynamic> json) =>
+    VanillaServerDownloadsServerInfo(
+      sha1: json['sha1'] as String,
+      size: json['size'] as int,
+      url: json['url'] as String,
+    );
+
+Map<String, dynamic> _$VanillaServerDownloadsServerInfoToJson(
+        VanillaServerDownloadsServerInfo instance) =>
+    <String, dynamic>{
+      'sha1': instance.sha1,
+      'size': instance.size,
+      'url': instance.url,
+    };

--- a/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_info.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_info.dart
@@ -1,0 +1,22 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:system_repository/src/vanilla_server/vanilla_server_downloads_info.dart';
+
+part 'vanilla_server_info.g.dart';
+
+@JsonSerializable()
+class VanillaServerInfo extends Equatable {
+  const VanillaServerInfo({
+    required this.downloads,
+  });
+
+  final VanillaServerDownloadsInfo downloads;
+
+  factory VanillaServerInfo.fromJson(Map<String, dynamic> json) =>
+      _$VanillaServerInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VanillaServerInfoToJson(this);
+
+  @override
+  List<Object> get props => [downloads];
+}

--- a/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_info.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_info.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:system_repository/src/vanilla_server/vanilla_server_downloads_info.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 part 'vanilla_server_info.g.dart';
 

--- a/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_info.g.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server/vanilla_server_info.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'vanilla_server_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+VanillaServerInfo _$VanillaServerInfoFromJson(Map<String, dynamic> json) =>
+    VanillaServerInfo(
+      downloads: VanillaServerDownloadsInfo.fromJson(
+          json['downloads'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$VanillaServerInfoToJson(VanillaServerInfo instance) =>
+    <String, dynamic>{
+      'downloads': instance.downloads,
+    };

--- a/packages/vanilla_server_repository/lib/src/vanilla_server_repository.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server_repository.dart
@@ -1,0 +1,31 @@
+import 'package:dio/dio.dart';
+import 'package:system_repository/vanilla_server_repository.dart';
+
+class VanillaServerRepository {
+  VanillaServerRepository({
+    Dio? dio,
+  }) : dio = dio ?? Dio();
+
+  static const _manifestUrl =
+      'https://launchermeta.mojang.com/mc/game/version_manifest_v2.json';
+
+  final Dio dio;
+
+  Future<List<VanillaManifestVersionInfo>> getServers() async {
+    final response = await dio.get(_manifestUrl);
+
+    final vanillaManifestInfo = VanillaManifestInfo.fromJson(response.data);
+
+    return vanillaManifestInfo.versions;
+  }
+
+  Future<VanillaServerDownloadsServerInfo> getServerByVersionInfo({
+    required String url,
+  }) async {
+    final response = await dio.get(url);
+
+    final vanillaServerInfo = VanillaServerInfo.fromJson(response.data);
+
+    return vanillaServerInfo.downloads.server;
+  }
+}

--- a/packages/vanilla_server_repository/lib/src/vanilla_server_repository.dart
+++ b/packages/vanilla_server_repository/lib/src/vanilla_server_repository.dart
@@ -1,5 +1,5 @@
 import 'package:dio/dio.dart';
-import 'package:system_repository/vanilla_server_repository.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 class VanillaServerRepository {
   VanillaServerRepository({

--- a/packages/vanilla_server_repository/lib/vanilla_server_repository.dart
+++ b/packages/vanilla_server_repository/lib/vanilla_server_repository.dart
@@ -1,4 +1,4 @@
-library system_repository;
+library vanilla_server_repository;
 
 export 'src/vanilla_server_repository.dart';
 export 'src/vanilla_manifest/vanilla_manifest.dart';

--- a/packages/vanilla_server_repository/lib/vanilla_server_repository.dart
+++ b/packages/vanilla_server_repository/lib/vanilla_server_repository.dart
@@ -1,0 +1,5 @@
+library system_repository;
+
+export 'src/vanilla_server_repository.dart';
+export 'src/vanilla_manifest/vanilla_manifest.dart';
+export 'src/vanilla_server/vanilla_server.dart';

--- a/packages/vanilla_server_repository/pubspec.yaml
+++ b/packages/vanilla_server_repository/pubspec.yaml
@@ -1,0 +1,35 @@
+name: system_repository
+description: A Dart Repository which the process cleanup domain.
+
+publish_to: none
+
+version: 1.0.0+1
+
+environment:
+  sdk: ">=2.14.0 <3.0.0"
+
+dependencies:
+  equatable: ^2.0.3
+  path: ^1.8.0
+  file: ^6.1.2
+  platform: ^3.1.0
+  process:
+    git: 
+      url: https://github.com/Tokenyet/process.dart.git
+      ref: 9a9b873604a0c8f58d1419e160146885fd8392b6
+  test_utilities:
+    path: ../test_utilities
+  dart_ipify: ^1.1.1
+  dio: ^4.0.4
+  validators: ^3.0.0
+  cube_api:
+    path: ../cube_api
+  json_annotation: ^4.7.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.1
+  mocktail: ^0.3.0
+  build_runner: ^2.1.7
+  json_serializable: ^6.1.4

--- a/packages/vanilla_server_repository/pubspec.yaml
+++ b/packages/vanilla_server_repository/pubspec.yaml
@@ -1,5 +1,5 @@
-name: system_repository
-description: A Dart Repository which the process cleanup domain.
+name: vanilla_server_repository
+description: A Dart Repository which fetching data from vanilla.
 
 publish_to: none
 

--- a/packages/vanilla_server_repository/test/vanilla_manifest_info_test.dart
+++ b/packages/vanilla_server_repository/test/vanilla_manifest_info_test.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:system_repository/src/vanilla_manifest/vanilla_manifest_info.dart';
+import 'package:system_repository/src/vanilla_manifest/vanilla_manifest_version_info.dart';
+
+void main() {
+  group('VanillaManifestInfo', () {
+    test('fromJson', () {
+      final result =
+          VanillaManifestInfo.fromJson(jsonDecode(givenVanillaManifestInfo));
+
+      final expectedVersion = [
+        VanillaManifestVersionInfo(
+          id: '23w04a',
+          type: 'snapshot',
+          url:
+              'https://piston-meta.mojang.com/v1/packages/6805751cb57fcb5a2f6fc24740d22b073e1536be/23w04a.json',
+          time: DateTime.utc(2023, 1, 24, 15, 28, 36),
+          releaseTime: DateTime.utc(2023, 1, 24, 15, 19, 6),
+        ),
+        VanillaManifestVersionInfo(
+          id: '23w03a',
+          type: 'snapshot',
+          url:
+              'https://piston-meta.mojang.com/v1/packages/b249a6b019b786da691980ae0489f881abf21718/23w03a.json',
+          time: DateTime.utc(2023, 1, 24, 14, 49, 13),
+          releaseTime: DateTime.utc(2023, 1, 18, 13, 10, 31),
+        ),
+        VanillaManifestVersionInfo(
+          id: '1.19.3',
+          type: 'release',
+          url:
+              'https://piston-meta.mojang.com/v1/packages/ff7960c2739033d6439f660ed11999322e6e6e99/1.19.3.json',
+          time: DateTime.utc(2023, 1, 24, 14, 49, 13),
+          releaseTime: DateTime.utc(2022, 12, 7, 8, 17, 18),
+        ),
+      ];
+      expect(result, VanillaManifestInfo(versions: expectedVersion));
+    });
+  });
+}
+
+const givenVanillaManifestInfo = r'''
+{
+  "latest": {
+    "release": "1.19.3",
+    "snapshot": "23w04a"
+  },
+  "versions": [
+    {
+      "id": "23w04a",
+      "type": "snapshot",
+      "url": "https://piston-meta.mojang.com/v1/packages/6805751cb57fcb5a2f6fc24740d22b073e1536be/23w04a.json",
+      "time": "2023-01-24T15:28:36+00:00",
+      "releaseTime": "2023-01-24T15:19:06+00:00",
+      "sha1": "6805751cb57fcb5a2f6fc24740d22b073e1536be",
+      "complianceLevel": 1
+    },
+    {
+      "id": "23w03a",
+      "type": "snapshot",
+      "url": "https://piston-meta.mojang.com/v1/packages/b249a6b019b786da691980ae0489f881abf21718/23w03a.json",
+      "time": "2023-01-24T14:49:13+00:00",
+      "releaseTime": "2023-01-18T13:10:31+00:00",
+      "sha1": "b249a6b019b786da691980ae0489f881abf21718",
+      "complianceLevel": 0
+    },
+    {
+      "id": "1.19.3",
+      "type": "release",
+      "url": "https://piston-meta.mojang.com/v1/packages/ff7960c2739033d6439f660ed11999322e6e6e99/1.19.3.json",
+      "time": "2023-01-24T14:49:13+00:00",
+      "releaseTime": "2022-12-07T08:17:18+00:00",
+      "sha1": "ff7960c2739033d6439f660ed11999322e6e6e99",
+      "complianceLevel": 1
+    }
+  ]
+}
+''';

--- a/packages/vanilla_server_repository/test/vanilla_manifest_info_test.dart
+++ b/packages/vanilla_server_repository/test/vanilla_manifest_info_test.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:system_repository/src/vanilla_manifest/vanilla_manifest_info.dart';
-import 'package:system_repository/src/vanilla_manifest/vanilla_manifest_version_info.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 void main() {
   group('VanillaManifestInfo', () {

--- a/packages/vanilla_server_repository/test/vanilla_server_info_test.dart
+++ b/packages/vanilla_server_repository/test/vanilla_server_info_test.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:system_repository/src/vanilla_server/vanilla_server_downloads_info.dart';
-import 'package:system_repository/src/vanilla_server/vanilla_server_downloads_server_info.dart';
-import 'package:system_repository/src/vanilla_server/vanilla_server_info.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 void main() {
   group('VanillaServerInfo', () {

--- a/packages/vanilla_server_repository/test/vanilla_server_info_test.dart
+++ b/packages/vanilla_server_repository/test/vanilla_server_info_test.dart
@@ -1,0 +1,1430 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:system_repository/src/vanilla_server/vanilla_server_downloads_info.dart';
+import 'package:system_repository/src/vanilla_server/vanilla_server_downloads_server_info.dart';
+import 'package:system_repository/src/vanilla_server/vanilla_server_info.dart';
+
+void main() {
+  group('VanillaServerInfo', () {
+    test('fromJson', () {
+      final result =
+          VanillaServerInfo.fromJson(jsonDecode(givenVanillaServerInfo));
+
+      const expected = VanillaServerInfo(
+        downloads: VanillaServerDownloadsInfo(
+          server: VanillaServerDownloadsServerInfo(
+            sha1: '2f31a8584ec1e70abd2d8b22d976feb52a6a3e31',
+            size: 47275073,
+            url:
+                'https://piston-data.mojang.com/v1/objects/2f31a8584ec1e70abd2d8b22d976feb52a6a3e31/server.jar',
+          ),
+        ),
+      );
+      expect(result, expected);
+    });
+  });
+}
+
+const givenVanillaServerInfo = r'''
+{
+  "arguments": {
+    "game": [
+      "--username",
+      "${auth_player_name}",
+      "--version",
+      "${version_name}",
+      "--gameDir",
+      "${game_directory}",
+      "--assetsDir",
+      "${assets_root}",
+      "--assetIndex",
+      "${assets_index_name}",
+      "--uuid",
+      "${auth_uuid}",
+      "--accessToken",
+      "${auth_access_token}",
+      "--clientId",
+      "${clientid}",
+      "--xuid",
+      "${auth_xuid}",
+      "--userType",
+      "${user_type}",
+      "--versionType",
+      "${version_type}",
+      {
+        "rules": [
+          {
+            "action": "allow",
+            "features": {
+              "is_demo_user": true
+            }
+          }
+        ],
+        "value": "--demo"
+      },
+      {
+        "rules": [
+          {
+            "action": "allow",
+            "features": {
+              "has_custom_resolution": true
+            }
+          }
+        ],
+        "value": [
+          "--width",
+          "${resolution_width}",
+          "--height",
+          "${resolution_height}"
+        ]
+      }
+    ],
+    "jvm": [
+      {
+        "rules": [
+          {
+            "action": "allow",
+            "os": {
+              "name": "osx"
+            }
+          }
+        ],
+        "value": [
+          "-XstartOnFirstThread"
+        ]
+      },
+      {
+        "rules": [
+          {
+            "action": "allow",
+            "os": {
+              "name": "windows"
+            }
+          }
+        ],
+        "value": "-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump"
+      },
+      {
+        "rules": [
+          {
+            "action": "allow",
+            "os": {
+              "name": "windows",
+              "version": "^10\\."
+            }
+          }
+        ],
+        "value": [
+          "-Dos.name=Windows 10",
+          "-Dos.version=10.0"
+        ]
+      },
+      {
+        "rules": [
+          {
+            "action": "allow",
+            "os": {
+              "arch": "x86"
+            }
+          }
+        ],
+        "value": "-Xss1M"
+      },
+      "-Djava.library.path=${natives_directory}",
+      "-Dminecraft.launcher.brand=${launcher_name}",
+      "-Dminecraft.launcher.version=${launcher_version}",
+      "-cp",
+      "${classpath}"
+    ]
+  },
+  "assetIndex": {
+    "id": "2",
+    "sha1": "63b14365d7df8a206d2fae60e3400d84bab5a7a4",
+    "size": 390746,
+    "totalSize": 549080055,
+    "url": "https://piston-meta.mojang.com/v1/packages/63b14365d7df8a206d2fae60e3400d84bab5a7a4/2.json"
+  },
+  "assets": "2",
+  "complianceLevel": 1,
+  "downloads": {
+    "client": {
+      "sha1": "2623aee01948e8ed29b3a52e5504c4d1fd63c7ae",
+      "size": 23006318,
+      "url": "https://piston-data.mojang.com/v1/objects/2623aee01948e8ed29b3a52e5504c4d1fd63c7ae/client.jar"
+    },
+    "client_mappings": {
+      "sha1": "4ef420245e54a29c2bbd38caf3d8d66964610756",
+      "size": 7660122,
+      "url": "https://piston-data.mojang.com/v1/objects/4ef420245e54a29c2bbd38caf3d8d66964610756/client.txt"
+    },
+    "server": {
+      "sha1": "2f31a8584ec1e70abd2d8b22d976feb52a6a3e31",
+      "size": 47275073,
+      "url": "https://piston-data.mojang.com/v1/objects/2f31a8584ec1e70abd2d8b22d976feb52a6a3e31/server.jar"
+    },
+    "server_mappings": {
+      "sha1": "868745891d933db0ae97afd7046416a2af961e86",
+      "size": 5914650,
+      "url": "https://piston-data.mojang.com/v1/objects/868745891d933db0ae97afd7046416a2af961e86/server.txt"
+    }
+  },
+  "id": "23w04a",
+  "javaVersion": {
+    "component": "java-runtime-gamma",
+    "majorVersion": 17
+  },
+  "libraries": [
+    {
+      "downloads": {
+        "artifact": {
+          "path": "ca/weblite/java-objc-bridge/1.1/java-objc-bridge-1.1.jar",
+          "sha1": "1227f9e0666314f9de41477e3ec277e542ed7f7b",
+          "size": 1330045,
+          "url": "https://libraries.minecraft.net/ca/weblite/java-objc-bridge/1.1/java-objc-bridge-1.1.jar"
+        }
+      },
+      "name": "ca.weblite:java-objc-bridge:1.1",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/github/oshi/oshi-core/6.2.2/oshi-core-6.2.2.jar",
+          "sha1": "54f5efc19bca95d709d9a37d19ffcbba3d21c1a6",
+          "size": 947865,
+          "url": "https://libraries.minecraft.net/com/github/oshi/oshi-core/6.2.2/oshi-core-6.2.2.jar"
+        }
+      },
+      "name": "com.github.oshi:oshi-core:6.2.2"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/google/code/gson/gson/2.10/gson-2.10.jar",
+          "sha1": "dd9b193aef96e973d5a11ab13cd17430c2e4306b",
+          "size": 286235,
+          "url": "https://libraries.minecraft.net/com/google/code/gson/gson/2.10/gson-2.10.jar"
+        }
+      },
+      "name": "com.google.code.gson:gson:2.10"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar",
+          "sha1": "1dcf1de382a0bf95a3d8b0849546c88bac1292c9",
+          "size": 4617,
+          "url": "https://libraries.minecraft.net/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
+        }
+      },
+      "name": "com.google.guava:failureaccess:1.0.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/google/guava/guava/31.1-jre/guava-31.1-jre.jar",
+          "sha1": "60458f877d055d0c9114d9e1a2efb737b4bc282c",
+          "size": 2959479,
+          "url": "https://libraries.minecraft.net/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar"
+        }
+      },
+      "name": "com.google.guava:guava:31.1-jre"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/ibm/icu/icu4j/71.1/icu4j-71.1.jar",
+          "sha1": "9e7d3304c23f9ba5cb71915f7cce23231a57a445",
+          "size": 13963762,
+          "url": "https://libraries.minecraft.net/com/ibm/icu/icu4j/71.1/icu4j-71.1.jar"
+        }
+      },
+      "name": "com.ibm.icu:icu4j:71.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/mojang/authlib/3.16.29/authlib-3.16.29.jar",
+          "sha1": "efcca7a2fd33a399287834787f3a899086752b14",
+          "size": 117060,
+          "url": "https://libraries.minecraft.net/com/mojang/authlib/3.16.29/authlib-3.16.29.jar"
+        }
+      },
+      "name": "com.mojang:authlib:3.16.29"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/mojang/blocklist/1.0.10/blocklist-1.0.10.jar",
+          "sha1": "5c685c5ffa94c4cd39496c7184c1d122e515ecef",
+          "size": 964,
+          "url": "https://libraries.minecraft.net/com/mojang/blocklist/1.0.10/blocklist-1.0.10.jar"
+        }
+      },
+      "name": "com.mojang:blocklist:1.0.10"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/mojang/brigadier/1.0.18/brigadier-1.0.18.jar",
+          "sha1": "c1ef1234282716483c92183f49bef47b1a89bfa9",
+          "size": 77116,
+          "url": "https://libraries.minecraft.net/com/mojang/brigadier/1.0.18/brigadier-1.0.18.jar"
+        }
+      },
+      "name": "com.mojang:brigadier:1.0.18"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/mojang/datafixerupper/5.0.28/datafixerupper-5.0.28.jar",
+          "sha1": "e2157e236e529aff80a5fc3ccb506e56d46b130b",
+          "size": 684966,
+          "url": "https://libraries.minecraft.net/com/mojang/datafixerupper/5.0.28/datafixerupper-5.0.28.jar"
+        }
+      },
+      "name": "com.mojang:datafixerupper:5.0.28"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/mojang/logging/1.1.1/logging-1.1.1.jar",
+          "sha1": "832b8e6674a9b325a5175a3a6267dfaf34c85139",
+          "size": 15343,
+          "url": "https://libraries.minecraft.net/com/mojang/logging/1.1.1/logging-1.1.1.jar"
+        }
+      },
+      "name": "com.mojang:logging:1.1.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/mojang/patchy/2.2.10/patchy-2.2.10.jar",
+          "sha1": "da05971b07cbb379d002cf7eaec6a2048211fefc",
+          "size": 4439,
+          "url": "https://libraries.minecraft.net/com/mojang/patchy/2.2.10/patchy-2.2.10.jar"
+        }
+      },
+      "name": "com.mojang:patchy:2.2.10"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/mojang/text2speech/1.13.9/text2speech-1.13.9.jar",
+          "sha1": "5f4e3a6ef86cb021f7ca87ca192cddb50c26eb59",
+          "size": 12123,
+          "url": "https://libraries.minecraft.net/com/mojang/text2speech/1.13.9/text2speech-1.13.9.jar"
+        }
+      },
+      "name": "com.mojang:text2speech:1.13.9"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/mojang/text2speech/1.13.9/text2speech-1.13.9-natives-linux.jar",
+          "sha1": "6c63ecb3b6408dcfdde6440c9ee62c060542af33",
+          "size": 7833,
+          "url": "https://libraries.minecraft.net/com/mojang/text2speech/1.13.9/text2speech-1.13.9-natives-linux.jar"
+        }
+      },
+      "name": "com.mojang:text2speech:1.13.9:natives-linux",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "com/mojang/text2speech/1.13.9/text2speech-1.13.9-natives-windows.jar",
+          "sha1": "7a90898b29e5c72f90ba6ebe86fa78a6afd7d3eb",
+          "size": 81379,
+          "url": "https://libraries.minecraft.net/com/mojang/text2speech/1.13.9/text2speech-1.13.9-natives-windows.jar"
+        }
+      },
+      "name": "com.mojang:text2speech:1.13.9:natives-windows",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "commons-codec/commons-codec/1.15/commons-codec-1.15.jar",
+          "sha1": "49d94806b6e3dc933dacbd8acb0fdbab8ebd1e5d",
+          "size": 353793,
+          "url": "https://libraries.minecraft.net/commons-codec/commons-codec/1.15/commons-codec-1.15.jar"
+        }
+      },
+      "name": "commons-codec:commons-codec:1.15"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "commons-io/commons-io/2.11.0/commons-io-2.11.0.jar",
+          "sha1": "a2503f302b11ebde7ebc3df41daebe0e4eea3689",
+          "size": 327135,
+          "url": "https://libraries.minecraft.net/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar"
+        }
+      },
+      "name": "commons-io:commons-io:2.11.0"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+          "sha1": "4bfc12adfe4842bf07b657f0369c4cb522955686",
+          "size": 61829,
+          "url": "https://libraries.minecraft.net/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
+        }
+      },
+      "name": "commons-logging:commons-logging:1.2"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-buffer/4.1.82.Final/netty-buffer-4.1.82.Final.jar",
+          "sha1": "a544270cf1ae8b8077082f5036436a9a9971ea71",
+          "size": 304664,
+          "url": "https://libraries.minecraft.net/io/netty/netty-buffer/4.1.82.Final/netty-buffer-4.1.82.Final.jar"
+        }
+      },
+      "name": "io.netty:netty-buffer:4.1.82.Final"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-codec/4.1.82.Final/netty-codec-4.1.82.Final.jar",
+          "sha1": "b77200379acb345a9ffdece1c605e591ac3e4e0a",
+          "size": 339155,
+          "url": "https://libraries.minecraft.net/io/netty/netty-codec/4.1.82.Final/netty-codec-4.1.82.Final.jar"
+        }
+      },
+      "name": "io.netty:netty-codec:4.1.82.Final"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-common/4.1.82.Final/netty-common-4.1.82.Final.jar",
+          "sha1": "022d148e85c3f5ebdacc0ce1f5aabb1d420f73f3",
+          "size": 653880,
+          "url": "https://libraries.minecraft.net/io/netty/netty-common/4.1.82.Final/netty-common-4.1.82.Final.jar"
+        }
+      },
+      "name": "io.netty:netty-common:4.1.82.Final"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-handler/4.1.82.Final/netty-handler-4.1.82.Final.jar",
+          "sha1": "644041d1fa96a5d3130a29e8978630d716d76e38",
+          "size": 538569,
+          "url": "https://libraries.minecraft.net/io/netty/netty-handler/4.1.82.Final/netty-handler-4.1.82.Final.jar"
+        }
+      },
+      "name": "io.netty:netty-handler:4.1.82.Final"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-resolver/4.1.82.Final/netty-resolver-4.1.82.Final.jar",
+          "sha1": "38f665ae8dcd29032eea31245ba7806bed2e0fa8",
+          "size": 37776,
+          "url": "https://libraries.minecraft.net/io/netty/netty-resolver/4.1.82.Final/netty-resolver-4.1.82.Final.jar"
+        }
+      },
+      "name": "io.netty:netty-resolver:4.1.82.Final"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-transport-classes-epoll/4.1.82.Final/netty-transport-classes-epoll-4.1.82.Final.jar",
+          "sha1": "e7c7dd18deac93105797f30057c912651ea76521",
+          "size": 142066,
+          "url": "https://libraries.minecraft.net/io/netty/netty-transport-classes-epoll/4.1.82.Final/netty-transport-classes-epoll-4.1.82.Final.jar"
+        }
+      },
+      "name": "io.netty:netty-transport-classes-epoll:4.1.82.Final"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-transport-native-epoll/4.1.82.Final/netty-transport-native-epoll-4.1.82.Final-linux-aarch_64.jar",
+          "sha1": "476409d6255001ca53a55f65b01c13822f8dc93a",
+          "size": 39489,
+          "url": "https://libraries.minecraft.net/io/netty/netty-transport-native-epoll/4.1.82.Final/netty-transport-native-epoll-4.1.82.Final-linux-aarch_64.jar"
+        }
+      },
+      "name": "io.netty:netty-transport-native-epoll:4.1.82.Final:linux-aarch_64",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-transport-native-epoll/4.1.82.Final/netty-transport-native-epoll-4.1.82.Final-linux-x86_64.jar",
+          "sha1": "c7350a71920f3ae9142945e25fed4846cce53374",
+          "size": 37922,
+          "url": "https://libraries.minecraft.net/io/netty/netty-transport-native-epoll/4.1.82.Final/netty-transport-native-epoll-4.1.82.Final-linux-x86_64.jar"
+        }
+      },
+      "name": "io.netty:netty-transport-native-epoll:4.1.82.Final:linux-x86_64",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-transport-native-unix-common/4.1.82.Final/netty-transport-native-unix-common-4.1.82.Final.jar",
+          "sha1": "3e895b35ca1b8a0eca56cacff4c2dde5d2c6abce",
+          "size": 43684,
+          "url": "https://libraries.minecraft.net/io/netty/netty-transport-native-unix-common/4.1.82.Final/netty-transport-native-unix-common-4.1.82.Final.jar"
+        }
+      },
+      "name": "io.netty:netty-transport-native-unix-common:4.1.82.Final"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "io/netty/netty-transport/4.1.82.Final/netty-transport-4.1.82.Final.jar",
+          "sha1": "e431a218d91acb6476ccad5f5aafde50aa3945ca",
+          "size": 485752,
+          "url": "https://libraries.minecraft.net/io/netty/netty-transport/4.1.82.Final/netty-transport-4.1.82.Final.jar"
+        }
+      },
+      "name": "io.netty:netty-transport:4.1.82.Final"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "it/unimi/dsi/fastutil/8.5.9/fastutil-8.5.9.jar",
+          "sha1": "bb7ea75ecdb216654237830b3a96d87ad91f8cc5",
+          "size": 23376043,
+          "url": "https://libraries.minecraft.net/it/unimi/dsi/fastutil/8.5.9/fastutil-8.5.9.jar"
+        }
+      },
+      "name": "it.unimi.dsi:fastutil:8.5.9"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "net/java/dev/jna/jna-platform/5.12.1/jna-platform-5.12.1.jar",
+          "sha1": "097406a297c852f4a41e688a176ec675f72e8329",
+          "size": 1356627,
+          "url": "https://libraries.minecraft.net/net/java/dev/jna/jna-platform/5.12.1/jna-platform-5.12.1.jar"
+        }
+      },
+      "name": "net.java.dev.jna:jna-platform:5.12.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar",
+          "sha1": "b1e93a735caea94f503e95e6fe79bf9cdc1e985d",
+          "size": 1866196,
+          "url": "https://libraries.minecraft.net/net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar"
+        }
+      },
+      "name": "net.java.dev.jna:jna:5.12.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar",
+          "sha1": "4fdac2fbe92dfad86aa6e9301736f6b4342a3f5c",
+          "size": 78146,
+          "url": "https://libraries.minecraft.net/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar"
+        }
+      },
+      "name": "net.sf.jopt-simple:jopt-simple:5.0.4"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar",
+          "sha1": "4ec95b60d4e86b5c95a0e919cb172a0af98011ef",
+          "size": 1018316,
+          "url": "https://libraries.minecraft.net/org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar"
+        }
+      },
+      "name": "org.apache.commons:commons-compress:1.21"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
+          "sha1": "c6842c86792ff03b9f1d1fe2aab8dc23aa6c6f0e",
+          "size": 587402,
+          "url": "https://libraries.minecraft.net/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+        }
+      },
+      "name": "org.apache.commons:commons-lang3:3.12.0"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar",
+          "sha1": "e5f6cae5ca7ecaac1ec2827a9e2d65ae2869cada",
+          "size": 780321,
+          "url": "https://libraries.minecraft.net/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar"
+        }
+      },
+      "name": "org.apache.httpcomponents:httpclient:4.5.13"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15.jar",
+          "sha1": "7f2e0c573eaa7a74bac2e89b359e1f73d92a0a1d",
+          "size": 328324,
+          "url": "https://libraries.minecraft.net/org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15.jar"
+        }
+      },
+      "name": "org.apache.httpcomponents:httpcore:4.4.15"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/apache/logging/log4j/log4j-api/2.19.0/log4j-api-2.19.0.jar",
+          "sha1": "ea1b37f38c327596b216542bc636cfdc0b8036fa",
+          "size": 317566,
+          "url": "https://libraries.minecraft.net/org/apache/logging/log4j/log4j-api/2.19.0/log4j-api-2.19.0.jar"
+        }
+      },
+      "name": "org.apache.logging.log4j:log4j-api:2.19.0"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/apache/logging/log4j/log4j-core/2.19.0/log4j-core-2.19.0.jar",
+          "sha1": "3b6eeb4de4c49c0fe38a4ee27188ff5fee44d0bb",
+          "size": 1864386,
+          "url": "https://libraries.minecraft.net/org/apache/logging/log4j/log4j-core/2.19.0/log4j-core-2.19.0.jar"
+        }
+      },
+      "name": "org.apache.logging.log4j:log4j-core:2.19.0"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/apache/logging/log4j/log4j-slf4j2-impl/2.19.0/log4j-slf4j2-impl-2.19.0.jar",
+          "sha1": "5c04bfdd63ce9dceb2e284b81e96b6a70010ee10",
+          "size": 27721,
+          "url": "https://libraries.minecraft.net/org/apache/logging/log4j/log4j-slf4j2-impl/2.19.0/log4j-slf4j2-impl-2.19.0.jar"
+        }
+      },
+      "name": "org.apache.logging.log4j:log4j-slf4j2-impl:2.19.0"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/joml/joml/1.10.5/joml-1.10.5.jar",
+          "sha1": "22566d58af70ad3d72308bab63b8339906deb649",
+          "size": 712082,
+          "url": "https://libraries.minecraft.net/org/joml/joml/1.10.5/joml-1.10.5.jar"
+        }
+      },
+      "name": "org.joml:joml:1.10.5"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+          "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+          "size": 128801,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-linux.jar",
+          "sha1": "81716978214ecbda15050ca394b06ef61501a49e",
+          "size": 119817,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-linux.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-linux",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos.jar",
+          "sha1": "9ec4ce1fc8c85fdef03ef4ff2aace6f5775fb280",
+          "size": 131655,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-macos",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar",
+          "sha1": "cac0d3f712a3da7641fa174735a5f315de7ffe0a",
+          "size": 129077,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-macos-arm64",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows.jar",
+          "sha1": "ed892f945cf7e79c8756796f32d00fa4ceaf573b",
+          "size": 145512,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-x86.jar",
+          "sha1": "b997e3391d6ce8f05487e7335d95c606043884a1",
+          "size": 139251,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-x86.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows-x86",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+          "sha1": "a817bcf213db49f710603677457567c37d53e103",
+          "size": 36601,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-linux.jar",
+          "sha1": "33dbb017b6ed6b25f993ad9d56741a49e7937718",
+          "size": 166524,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-linux.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos.jar",
+          "sha1": "56424dc8db3cfb8e7b594aa6d59a4f4387b7f544",
+          "size": 117480,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-macos",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar",
+          "sha1": "e577b87d8ad2ade361aaea2fcf226c660b15dee8",
+          "size": 103475,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-macos-arm64",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows.jar",
+          "sha1": "948a89b76a16aa324b046ae9308891216ffce5f9",
+          "size": 135585,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-x86.jar",
+          "sha1": "fb476c8ec110e1c137ad3ce8a7f7bfe6b11c6324",
+          "size": 110405,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-x86.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows-x86",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+          "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+          "size": 88237,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-openal:3.3.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-linux.jar",
+          "sha1": "f906b6439f6daa66001182ea7727e3467a93681b",
+          "size": 476825,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-linux.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-linux",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos.jar",
+          "sha1": "3a57b8911835fb58b5e558d0ca0d28157e263d45",
+          "size": 397196,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-macos",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar",
+          "sha1": "23d55e7490b57495320f6c9e1936d78fd72c4ef8",
+          "size": 346125,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-macos-arm64",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows.jar",
+          "sha1": "30a474d0e57193d7bc128849a3ab66bc9316fdb1",
+          "size": 576872,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-windows",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-x86.jar",
+          "sha1": "888349f7b1be6fbae58bf8edfb9ef12def04c4e3",
+          "size": 520313,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-x86.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-windows-x86",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+          "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+          "size": 921563,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-linux.jar",
+          "sha1": "ab9ab6fde3743e3550fa5d46d785ecb45b047d99",
+          "size": 79125,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-linux.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos.jar",
+          "sha1": "a0d12697ea019a7362eff26475b0531340e876a6",
+          "size": 40709,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-macos",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar",
+          "sha1": "eafe34b871d966292e8db0f1f3d6b8b110d4e91d",
+          "size": 41665,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-macos-arm64",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows.jar",
+          "sha1": "c1807e9bd571402787d7e37e3029776ae2513bb8",
+          "size": 100205,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-x86.jar",
+          "sha1": "deef3eb9b178ff2ff3ce893cc72ae741c3a17974",
+          "size": 87463,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-x86.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows-x86",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+          "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+          "size": 112380,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-stb:3.3.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-linux.jar",
+          "sha1": "3ee7aec8686e52867677110415566a5342a80230",
+          "size": 227237,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-linux.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-linux",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos.jar",
+          "sha1": "def8879b8d38a47a4cc1d48b1f9a7b772e51258e",
+          "size": 203582,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-macos",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar",
+          "sha1": "fcf073ed911752abdca5f0b00a53cfdf17ff8e8b",
+          "size": 178408,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-macos-arm64",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows.jar",
+          "sha1": "86315914ac119efdb02dc9e8e978ade84f1702af",
+          "size": 256301,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-windows",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-x86.jar",
+          "sha1": "a8d41f419eecb430b7c91ea2ce2c5c451cae2091",
+          "size": 225147,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-x86.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-windows-x86",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+          "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+          "size": 6767,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-linux.jar",
+          "sha1": "a35110b9471bea8cde826ab297550ee8c22f5035",
+          "size": 45389,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-linux.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-linux",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos.jar",
+          "sha1": "78641a0fa5e9afa714adfdd152c357930c97a1ce",
+          "size": 44821,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-macos",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar",
+          "sha1": "972ecc17bad3571e81162153077b4d47b7b9eaa9",
+          "size": 41380,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-macos-arm64",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows.jar",
+          "sha1": "a5d830475ec0958d9fdba1559efa99aef211e6ff",
+          "size": 127930,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-x86.jar",
+          "sha1": "842eedd876fae354abc308c98a263f6bbc9e8a4d",
+          "size": 110042,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-x86.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows-x86",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+          "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+          "size": 724243,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl:3.3.1"
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-linux.jar",
+          "sha1": "1de885aba434f934201b99f2f1afb142036ac189",
+          "size": 110704,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-linux.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl:3.3.1:natives-linux",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos.jar",
+          "sha1": "fc6bb723dec2cd031557dccb2a95f0ab80acb9db",
+          "size": 55706,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl:3.3.1:natives-macos",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar",
+          "sha1": "71d0d5e469c9c95351eb949064497e3391616ac9",
+          "size": 42693,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl:3.3.1:natives-macos-arm64",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "osx"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows.jar",
+          "sha1": "0036c37f16ab611b3aa11f3bcf80b1d509b4ce6b",
+          "size": 159361,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl:3.3.1:natives-windows",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-x86.jar",
+          "sha1": "3b14f4beae9dd39791ec9e12190a9380cd8a3ce6",
+          "size": 134695,
+          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-x86.jar"
+        }
+      },
+      "name": "org.lwjgl:lwjgl:3.3.1:natives-windows-x86",
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "windows"
+          }
+        }
+      ]
+    },
+    {
+      "downloads": {
+        "artifact": {
+          "path": "org/slf4j/slf4j-api/2.0.1/slf4j-api-2.0.1.jar",
+          "sha1": "f48d81adce2abf5ad3cfe463df517952749e03bc",
+          "size": 61388,
+          "url": "https://libraries.minecraft.net/org/slf4j/slf4j-api/2.0.1/slf4j-api-2.0.1.jar"
+        }
+      },
+      "name": "org.slf4j:slf4j-api:2.0.1"
+    }
+  ],
+  "logging": {
+    "client": {
+      "argument": "-Dlog4j.configurationFile=${path}",
+      "file": {
+        "id": "client-1.12.xml",
+        "sha1": "bd65e7d2e3c237be76cfbef4c2405033d7f91521",
+        "size": 888,
+        "url": "https://launcher.mojang.com/v1/objects/bd65e7d2e3c237be76cfbef4c2405033d7f91521/client-1.12.xml"
+      },
+      "type": "log4j2-xml"
+    }
+  },
+  "mainClass": "net.minecraft.client.main.Main",
+  "minimumLauncherVersion": 21,
+  "releaseTime": "2023-01-24T15:19:06+00:00",
+  "time": "2023-01-24T15:19:06+00:00",
+  "type": "snapshot"
+}
+''';

--- a/packages/vanilla_server_repository/test/vanilla_server_repository_ig_test.dart
+++ b/packages/vanilla_server_repository/test/vanilla_server_repository_ig_test.dart
@@ -1,0 +1,53 @@
+@Tags(['integration'])
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('VanillaServerRepository (Ignore for third party api)', () {
+    // late SystemRepository repository;
+
+    // setUp(
+    //   () {
+    //     repository = const SystemRepository();
+    //   },
+    // );
+
+    // group('constructor', () {
+    //   test('instantiates internal process when not injected', () {
+    //     expect(const SystemRepository(), isNotNull);
+    //   });
+    // });
+
+    // group('getCpuInfo', () {
+    //   test('return correct CpuInfo', () async {
+    //     final cpu = await repository.getCpuInfo();
+    //     expect(
+    //       cpu.name,
+    //       isNotEmpty,
+    //     );
+    //     expect(
+    //       cpu.load,
+    //       greaterThan(0),
+    //     );
+    //   });
+    // });
+    // group('getMemoryInfo', () {
+    //   test('return correct MemoryInfo', () async {
+    //     final memoryInfo = await repository.getMemoryInfo();
+    //     expect(
+    //       memoryInfo.freeSize,
+    //       greaterThan(0),
+    //     );
+    //     expect(memoryInfo.totalSize, greaterThan(0));
+    //   });
+    // });
+    // group('getGpuInfo', () {
+    //   test('return correct GpuName (nogui?)', () async {
+    //     expect(
+    //       await repository.getGpuInfo(),
+    //       isNotEmpty,
+    //     );
+    //   });
+    // });
+  });
+}

--- a/packages/vanilla_server_repository/test/vanilla_server_repository_ig_test.dart
+++ b/packages/vanilla_server_repository/test/vanilla_server_repository_ig_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('VanillaServerRepository (Ignore for third party api)', () {
+    test('dummy test for melos#261 and flutter#100467', () {});
+
     // late SystemRepository repository;
 
     // setUp(

--- a/packages/vanilla_server_repository/test/vanilla_server_repository_test.dart
+++ b/packages/vanilla_server_repository/test/vanilla_server_repository_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:system_repository/vanilla_server_repository.dart';
+
+import 'vanilla_manifest_info_test.dart' show givenVanillaManifestInfo;
+import 'vanilla_server_info_test.dart' show givenVanillaServerInfo;
+
+class MockDio extends Mock implements Dio {}
+
+class MockResponse extends Mock implements Response {}
+
+void main() {
+  final givenVanillaManifestInfoMap = jsonDecode(givenVanillaManifestInfo);
+  final givenVanillaServerInfoMap = jsonDecode(givenVanillaServerInfo);
+  group('VanillaServerRepository', () {
+    // late Platform platform;
+    // late ProcessManager processManager;
+    late Dio mockDio;
+    late VanillaServerRepository repository;
+
+    setUp(
+      () {
+        mockDio = MockDio();
+        repository = VanillaServerRepository(dio: mockDio);
+      },
+    );
+
+    group('constructor', () {
+      test('instantiates successfully when not injected', () {
+        expect(VanillaServerRepository(), isNotNull);
+      });
+    });
+
+    group('getServers', () {
+      test(
+          'Given successfully response from mock api '
+          'When calling getServers '
+          'Then should return a list of [VanillaManifestVersionInfo]',
+          () async {
+        final response = MockResponse();
+        when(() => mockDio.get(any())).thenAnswer((_) async => response);
+        when(() => response.data).thenReturn(givenVanillaManifestInfoMap);
+
+        final results = await repository.getServers();
+
+        final expectedVersions = [
+          VanillaManifestVersionInfo(
+            id: '23w04a',
+            type: 'snapshot',
+            url:
+                'https://piston-meta.mojang.com/v1/packages/6805751cb57fcb5a2f6fc24740d22b073e1536be/23w04a.json',
+            time: DateTime.utc(2023, 1, 24, 15, 28, 36),
+            releaseTime: DateTime.utc(2023, 1, 24, 15, 19, 6),
+          ),
+          VanillaManifestVersionInfo(
+            id: '23w03a',
+            type: 'snapshot',
+            url:
+                'https://piston-meta.mojang.com/v1/packages/b249a6b019b786da691980ae0489f881abf21718/23w03a.json',
+            time: DateTime.utc(2023, 1, 24, 14, 49, 13),
+            releaseTime: DateTime.utc(2023, 1, 18, 13, 10, 31),
+          ),
+          VanillaManifestVersionInfo(
+            id: '1.19.3',
+            type: 'release',
+            url:
+                'https://piston-meta.mojang.com/v1/packages/ff7960c2739033d6439f660ed11999322e6e6e99/1.19.3.json',
+            time: DateTime.utc(2023, 1, 24, 14, 49, 13),
+            releaseTime: DateTime.utc(2022, 12, 7, 8, 17, 18),
+          ),
+        ];
+        expect(results, expectedVersions);
+      });
+    });
+
+    group('getServerByVersionInfo', () {
+      test(
+          'Given successfully response from mock api '
+          'When calling [getServerByVersionInfo] with correct url'
+          'Then should return [VanillaServerDownloadsServerInfo]', () async {
+        const url =
+            'https://piston-meta.mojang.com/v1/packages/6805751cb57fcb5a2f6fc24740d22b073e1536be/23w04a.json';
+        final response = MockResponse();
+        when(() => mockDio.get(url)).thenAnswer((_) async => response);
+        when(() => response.data).thenReturn(givenVanillaServerInfoMap);
+
+        final result = await repository.getServerByVersionInfo(url: url);
+
+        const expected = VanillaServerDownloadsServerInfo(
+          sha1: '2f31a8584ec1e70abd2d8b22d976feb52a6a3e31',
+          size: 47275073,
+          url:
+              'https://piston-data.mojang.com/v1/objects/2f31a8584ec1e70abd2d8b22d976feb52a6a3e31/server.jar',
+        );
+        expect(result, expected);
+      });
+    });
+  });
+}

--- a/packages/vanilla_server_repository/test/vanilla_server_repository_test.dart
+++ b/packages/vanilla_server_repository/test/vanilla_server_repository_test.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:system_repository/vanilla_server_repository.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 import 'vanilla_manifest_info_test.dart' show givenVanillaManifestInfo;
 import 'vanilla_server_info_test.dart' show givenVanillaServerInfo;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,6 +118,8 @@ dependencies:
     path: ./packages/server_repository
   system_repository:
     path: ./packages/system_repository
+  vanilla_server_repository:
+    path: ./packages/vanilla_server_repository
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   validators: ^3.0.0
 
   # widgets
-  dropdown_button2: ^1.1.1
+  dropdown_button2: ^1.9.2
   flutter_typeahead: ^4.0.0
   # overlay_builder: ^1.1.0
   # flutter_portal: ^0.4.0

--- a/test/lib/pages/app_page/pages/server_page/bloc/installer_manager_cubit_test.dart
+++ b/test/lib/pages/app_page/pages/server_page/bloc/installer_manager_cubit_test.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:cube_api/cube_api.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:installer_creator_repository/installer_creator_repository.dart';
 import 'package:minecraft_cube_desktop/pages/app_page/pages/server_page/bloc/installer_manager_cubit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:server_management_repository/server_management_repository.dart';
@@ -12,12 +13,17 @@ class MockServerManagementRepository extends Mock
 class MockVanillaServerRepository extends Mock
     implements VanillaServerRepository {}
 
+class MockInstallerCreatorRepository extends Mock
+    implements InstallerCreatorRepository {}
+
 void main() {
   late ServerManagementRepository serverManagementRepository;
   late VanillaServerRepository vanillaServerRepository;
+  late InstallerCreatorRepository installerCreatorRepository;
   setUp(() {
     serverManagementRepository = MockServerManagementRepository();
     vanillaServerRepository = MockVanillaServerRepository();
+    installerCreatorRepository = MockInstallerCreatorRepository();
   });
 
   final givenVanillaManifestVersionInfo = VanillaManifestVersionInfo(
@@ -35,6 +41,7 @@ void main() {
         build: () => InstallerManagerCubit(
           serverManagementRepository: serverManagementRepository,
           vanillaServerRepository: vanillaServerRepository,
+          installerCreatorRepository: installerCreatorRepository,
         ),
         setUp: () {
           when(() => serverManagementRepository.getInstallers())
@@ -61,6 +68,7 @@ void main() {
         build: () => InstallerManagerCubit(
           serverManagementRepository: serverManagementRepository,
           vanillaServerRepository: vanillaServerRepository,
+          installerCreatorRepository: installerCreatorRepository,
         ),
         setUp: () {
           when(() => serverManagementRepository.getInstallers())
@@ -86,6 +94,7 @@ void main() {
         build: () => InstallerManagerCubit(
           serverManagementRepository: serverManagementRepository,
           vanillaServerRepository: vanillaServerRepository,
+          installerCreatorRepository: installerCreatorRepository,
         ),
         setUp: () {
           when(() => serverManagementRepository.getInstallers()).thenAnswer(
@@ -123,6 +132,281 @@ void main() {
               ],
             ),
           ];
+        },
+      );
+    });
+
+    group('getVanillaInstaller', () {
+      const url = 'targetUrl';
+      const name = 'name';
+      const description = 'description';
+      const server = 'server';
+      const type = JarType.vanilla;
+      final vanillaManifestInfo = VanillaManifestVersionInfo(
+        id: 'id',
+        type: 'type',
+        url: url,
+        time: DateTime.now(),
+        releaseTime: DateTime.now(),
+      );
+      const vanillaServerDownloadServerInfo =
+          VanillaServerDownloadsServerInfo(sha1: '1', size: 1, url: '1');
+
+      blocTest<InstallerManagerCubit, InstallerManagerState>(
+        'emits [loading, failure] when getServerByVersionInfo throws',
+        build: () => InstallerManagerCubit(
+          serverManagementRepository: serverManagementRepository,
+          vanillaServerRepository: vanillaServerRepository,
+          installerCreatorRepository: installerCreatorRepository,
+        ),
+        setUp: () {
+          when(
+            () => vanillaServerRepository.getServerByVersionInfo(
+              url: captureAny(named: 'url'),
+            ),
+          ).thenThrow(
+            Exception(),
+          );
+          when(
+            () => serverManagementRepository.createInstallersDir(
+              subfolder: '_vanilla',
+            ),
+          ).thenAnswer((_) async => '');
+          when(
+            () => installerCreatorRepository.create(
+              name: captureAny(named: 'name'),
+              description: captureAny(named: 'description'),
+              server: captureAny(named: 'server'),
+              pack: captureAny(named: 'pack'),
+              map: captureAny(named: 'map'),
+              settings: captureAny(named: 'settings'),
+              type: JarType.vanilla,
+              subfolder: '_vanilla',
+            ),
+          ).thenAnswer(
+            (_) async =>
+                const MapEntry('', Installer(name, description, type, server)),
+          );
+        },
+        act: (cubit) =>
+            cubit.getVanillaInstaller(vanillaManifest: vanillaManifestInfo),
+        expect: () {
+          return <InstallerManagerState>[
+            const InstallerManagerState(
+              status: NetworkStatus.inProgress,
+              installers: [],
+              vanillaVersions: [],
+            ),
+            const InstallerManagerState(
+              status: NetworkStatus.failure,
+              installers: [],
+              vanillaVersions: [],
+            ),
+          ];
+        },
+        verify: (_) {
+          final captured = verify(
+            () => vanillaServerRepository.getServerByVersionInfo(
+              url: captureAny(named: 'url'),
+            ),
+          ).captured;
+          expect(captured, [url]);
+        },
+      );
+
+      blocTest<InstallerManagerCubit, InstallerManagerState>(
+        'emits [loading, failure] when createInstallersDir throws',
+        build: () => InstallerManagerCubit(
+          serverManagementRepository: serverManagementRepository,
+          vanillaServerRepository: vanillaServerRepository,
+          installerCreatorRepository: installerCreatorRepository,
+        ),
+        setUp: () {
+          when(
+            () => vanillaServerRepository.getServerByVersionInfo(
+              url: captureAny(named: 'url'),
+            ),
+          ).thenAnswer(
+            (_) async => vanillaServerDownloadServerInfo,
+          );
+          when(
+            () => serverManagementRepository.createInstallersDir(
+              subfolder: '_vanilla',
+            ),
+          ).thenThrow(Exception());
+          when(
+            () => installerCreatorRepository.create(
+              name: captureAny(named: 'name'),
+              description: captureAny(named: 'description'),
+              server: captureAny(named: 'server'),
+              pack: captureAny(named: 'pack'),
+              map: captureAny(named: 'map'),
+              settings: captureAny(named: 'settings'),
+              type: JarType.vanilla,
+              subfolder: '_vanilla',
+            ),
+          ).thenAnswer(
+            (_) async =>
+                const MapEntry('', Installer(name, description, type, server)),
+          );
+        },
+        act: (cubit) =>
+            cubit.getVanillaInstaller(vanillaManifest: vanillaManifestInfo),
+        expect: () {
+          return <InstallerManagerState>[
+            const InstallerManagerState(
+              status: NetworkStatus.inProgress,
+              installers: [],
+              vanillaVersions: [],
+            ),
+            const InstallerManagerState(
+              status: NetworkStatus.failure,
+              installers: [],
+              vanillaVersions: [],
+            ),
+          ];
+        },
+        verify: (_) {
+          final captured = verify(
+            () => vanillaServerRepository.getServerByVersionInfo(
+              url: captureAny(named: 'url'),
+            ),
+          ).captured;
+          expect(captured, [url]);
+        },
+      );
+
+      blocTest<InstallerManagerCubit, InstallerManagerState>(
+        'emits [loading, failure] when installerCreatorRepository.create throws',
+        build: () => InstallerManagerCubit(
+          serverManagementRepository: serverManagementRepository,
+          vanillaServerRepository: vanillaServerRepository,
+          installerCreatorRepository: installerCreatorRepository,
+        ),
+        setUp: () {
+          when(
+            () => vanillaServerRepository.getServerByVersionInfo(
+              url: captureAny(named: 'url'),
+            ),
+          ).thenAnswer(
+            (_) async => vanillaServerDownloadServerInfo,
+          );
+          when(
+            () => serverManagementRepository.createInstallersDir(
+              subfolder: '_vanilla',
+            ),
+          ).thenAnswer((_) async => '');
+          when(
+            () => installerCreatorRepository.create(
+              name: captureAny(named: 'name'),
+              description: captureAny(named: 'description'),
+              server: captureAny(named: 'server'),
+              pack: captureAny(named: 'pack'),
+              map: captureAny(named: 'map'),
+              settings: captureAny(named: 'settings'),
+              type: JarType.vanilla,
+              subfolder: '_vanilla',
+            ),
+          ).thenThrow(
+            Exception(),
+          );
+        },
+        act: (cubit) =>
+            cubit.getVanillaInstaller(vanillaManifest: vanillaManifestInfo),
+        expect: () {
+          return <InstallerManagerState>[
+            const InstallerManagerState(
+              status: NetworkStatus.inProgress,
+              installers: [],
+              vanillaVersions: [],
+            ),
+            const InstallerManagerState(
+              status: NetworkStatus.failure,
+              installers: [],
+              vanillaVersions: [],
+            ),
+          ];
+        },
+        verify: (_) {
+          final captured = verify(
+            () => vanillaServerRepository.getServerByVersionInfo(
+              url: captureAny(named: 'url'),
+            ),
+          ).captured;
+          expect(captured, [url]);
+        },
+      );
+
+      const entry =
+          MapEntry('installerPath', Installer(name, description, type, server));
+      blocTest<InstallerManagerCubit, InstallerManagerState>(
+        'emits [loading, success]',
+        build: () => InstallerManagerCubit(
+          serverManagementRepository: serverManagementRepository,
+          vanillaServerRepository: vanillaServerRepository,
+          installerCreatorRepository: installerCreatorRepository,
+        ),
+        setUp: () {
+          when(
+            () => vanillaServerRepository.getServerByVersionInfo(
+              url: captureAny(named: 'url'),
+            ),
+          ).thenAnswer(
+            (_) async => vanillaServerDownloadServerInfo,
+          );
+          when(
+            () => serverManagementRepository.createInstallersDir(
+              subfolder: '_vanilla',
+            ),
+          ).thenAnswer((_) async => '');
+          when(
+            () => installerCreatorRepository.create(
+              name: captureAny(named: 'name'),
+              description: captureAny(named: 'description'),
+              server: captureAny(named: 'server'),
+              pack: captureAny(named: 'pack'),
+              map: captureAny(named: 'map'),
+              settings: captureAny(named: 'settings'),
+              type: JarType.vanilla,
+              subfolder: '_vanilla',
+            ),
+          ).thenAnswer(
+            (_) async => entry,
+          );
+        },
+        act: (cubit) async {
+          final result = await cubit.getVanillaInstaller(
+            vanillaManifest: vanillaManifestInfo,
+          );
+          expect(
+            result,
+            InstallerFile(
+              installer: entry.value,
+              path: entry.key,
+            ),
+          );
+        },
+        expect: () {
+          return <InstallerManagerState>[
+            const InstallerManagerState(
+              status: NetworkStatus.inProgress,
+              installers: [],
+              vanillaVersions: [],
+            ),
+            const InstallerManagerState(
+              status: NetworkStatus.success,
+              installers: [],
+              vanillaVersions: [],
+            ),
+          ];
+        },
+        verify: (_) {
+          final captured = verify(
+            () => vanillaServerRepository.getServerByVersionInfo(
+              url: captureAny(named: 'url'),
+            ),
+          ).captured;
+          expect(captured, [url]);
         },
       );
     });

--- a/test/lib/pages/app_page/pages/server_page/bloc/installer_manager_cubit_test.dart
+++ b/test/lib/pages/app_page/pages/server_page/bloc/installer_manager_cubit_test.dart
@@ -4,15 +4,29 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minecraft_cube_desktop/pages/app_page/pages/server_page/bloc/installer_manager_cubit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:server_management_repository/server_management_repository.dart';
+import 'package:vanilla_server_repository/vanilla_server_repository.dart';
 
 class MockServerManagementRepository extends Mock
     implements ServerManagementRepository {}
 
+class MockVanillaServerRepository extends Mock
+    implements VanillaServerRepository {}
+
 void main() {
   late ServerManagementRepository serverManagementRepository;
+  late VanillaServerRepository vanillaServerRepository;
   setUp(() {
     serverManagementRepository = MockServerManagementRepository();
+    vanillaServerRepository = MockVanillaServerRepository();
   });
+
+  final givenVanillaManifestVersionInfo = VanillaManifestVersionInfo(
+    id: 'id',
+    type: 'type',
+    url: 'url',
+    time: DateTime.now(),
+    releaseTime: DateTime.now(),
+  );
 
   group('InstallerManagerCubit', () {
     group('getInstallers', () {
@@ -20,24 +34,33 @@ void main() {
         'emits [] when not found anything.',
         build: () => InstallerManagerCubit(
           serverManagementRepository: serverManagementRepository,
+          vanillaServerRepository: vanillaServerRepository,
         ),
         setUp: () {
           when(() => serverManagementRepository.getInstallers())
               .thenAnswer((_) => Stream.fromIterable([]));
+          when(() => vanillaServerRepository.getServers())
+              .thenAnswer((_) async => []);
         },
         act: (cubit) => cubit.getInstallers(),
         expect: () => const <InstallerManagerState>[
           InstallerManagerState(
             status: NetworkStatus.inProgress,
             installers: [],
+            vanillaVersions: [],
           ),
-          InstallerManagerState(status: NetworkStatus.success, installers: []),
+          InstallerManagerState(
+            status: NetworkStatus.success,
+            installers: [],
+            vanillaVersions: [],
+          ),
         ],
       );
       blocTest<InstallerManagerCubit, InstallerManagerState>(
         'emits [loading, failure] when unexpected.',
         build: () => InstallerManagerCubit(
           serverManagementRepository: serverManagementRepository,
+          vanillaServerRepository: vanillaServerRepository,
         ),
         setUp: () {
           when(() => serverManagementRepository.getInstallers())
@@ -48,8 +71,13 @@ void main() {
           InstallerManagerState(
             status: NetworkStatus.inProgress,
             installers: [],
+            vanillaVersions: [],
           ),
-          InstallerManagerState(status: NetworkStatus.failure, installers: []),
+          InstallerManagerState(
+            status: NetworkStatus.failure,
+            installers: [],
+            vanillaVersions: [],
+          ),
         ],
       );
 
@@ -57,6 +85,7 @@ void main() {
         'emits [loading, success]',
         build: () => InstallerManagerCubit(
           serverManagementRepository: serverManagementRepository,
+          vanillaServerRepository: vanillaServerRepository,
         ),
         setUp: () {
           when(() => serverManagementRepository.getInstallers()).thenAnswer(
@@ -68,22 +97,29 @@ void main() {
               ),
             ]),
           );
+          when(() => vanillaServerRepository.getServers()).thenAnswer(
+            (_) async => [givenVanillaManifestVersionInfo],
+          );
         },
         act: (cubit) => cubit.getInstallers(),
         expect: () {
-          return const <InstallerManagerState>[
-            InstallerManagerState(
+          return <InstallerManagerState>[
+            const InstallerManagerState(
               status: NetworkStatus.inProgress,
               installers: [],
+              vanillaVersions: [],
             ),
             InstallerManagerState(
               status: NetworkStatus.success,
-              installers: [
+              installers: const [
                 InstallerFile(
                   installer:
                       Installer('name', 'description', JarType.vanilla, 'path'),
                   path: 'anypath',
                 ),
+              ],
+              vanillaVersions: [
+                givenVanillaManifestVersionInfo,
               ],
             ),
           ];


### PR DESCRIPTION
This PR did the following things:
- Add `vanilla_server_repository` for getting data from `manifest_v2.json` and `<version>.json`.
- Modify `InstallerCreatorRepository`  and `ServerManagementRepository` to support create subfolder into `installer`.

The retro:
- Avoid duplicating the logic on multiple repository.
- Should repository use another repository?